### PR TITLE
check whether firewall rules already exist before adding them

### DIFF
--- a/src/openwrt/br-config.sh
+++ b/src/openwrt/br-config.sh
@@ -5,11 +5,17 @@ uci get network.thread.ifname && \
 	logger -t br-config Thread network interface and firewall already configured! && \
 	exit 0  
 
-logger -t br-config Configuring Thread network interface and firewall rules...
+logger -t br-config Configuring Thread network interface...
 
 uci set network.thread=interface
 uci set network.thread.ifname='wpan0'
 uci set network.thread.proto='static'
+
+uci show firewall | grep thread && \
+	logger -t br-config Thread firewall rules already configured! && \
+	exit 0
+
+logger -t br-config Configuring Thread firewall rules...
 
 uci add firewall zone > /dev/null
 uci set firewall.@zone[-1].name='thread'


### PR DESCRIPTION
We have been seeing connectivity to the internet go down over IPv4 after adding new firewall rules. I found out that the Thread-specific firewall rules can end up applied twice, which breaks internet access for devices connected to the LAN interface.

This PR checks whether the firewall rules are already configured before adding them again.