### PR TITLE
disable promiscuous mode on eth0 & wpan0

### DIFF
--- a/src/openwrt/smcroute
+++ b/src/openwrt/smcroute
@@ -6,8 +6,6 @@ PROG=/usr/sbin/smcrouted
 
 start_service() {
 	sleep 4
-	ifconfig eth0 promisc
-	ifconfig wpan0 promisc
 	/lib/br-config.sh
 	/lib/br-omr-enable.sh
 	/lib/br-smcroute-prefix.sh


### PR DESCRIPTION
This was originally turned on in order to enable routing of discovery & s-mode messages. This feature is now enabled by (better) custom routes in smcroute, and testing with the latest ETS reveals that Thread devices can still be discovered, programmed & controlled using the group monitor.

This pull request disables promiscuous mode on the eth0 & wpan0 interfaces, which should improve the performance of the router.